### PR TITLE
OPENEUROPA-2003: Allow other modules to resolve oembed responses for other source plugins

### DIFF
--- a/oe_oembed.services.yml
+++ b/oe_oembed.services.yml
@@ -1,4 +1,4 @@
 services:
   oe_oembed.oembed_resolver:
     class: Drupal\oe_oembed\Oembed\OembedResolver
-    arguments: ['@entity.repository', '@renderer', '@entity_type.manager']
+    arguments: ['@entity.repository', '@renderer', '@entity_type.manager', '@event_dispatcher']

--- a/src/Event/OembedResolverAlter.php
+++ b/src/Event/OembedResolverAlter.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_oembed\Event;
+
+use Drupal\media\MediaInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Used for altering the return value of the OembedResolver.
+ */
+class OembedResolverAlter extends Event {
+
+  /**
+   * The name of the event.
+   */
+  const OEMBED_RESOLVER_ALTER = 'oembed_resolver_alter';
+
+  /**
+   * The media entity being resolved.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  protected $media;
+
+  /**
+   * The query params in the resource URL.
+   *
+   * @var array
+   */
+  protected $queryParams = [];
+
+  /**
+   * The resolved data to be altered.
+   *
+   * @var array
+   */
+  protected $data = [];
+
+  /**
+   * OembedResolverAlter constructor.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity being resolved.
+   * @param array $query_params
+   *   The query params in the resource URL.
+   * @param array $data
+   *   The resolved data to be altered.
+   */
+  public function __construct(MediaInterface $media, array $query_params, array $data) {
+    $this->media = $media;
+    $this->queryParams = $query_params;
+    $this->data = $data;
+  }
+
+  /**
+   * Returns the media entity.
+   *
+   * @return \Drupal\media\MediaInterface
+   *   The media entity.
+   */
+  public function getMedia(): MediaInterface {
+    return $this->media;
+  }
+
+  /**
+   * Returns the resource URL query parameters.
+   *
+   * @return array
+   *   The query params.
+   */
+  public function getQueryParams(): array {
+    return $this->queryParams;
+  }
+
+  /**
+   * Returns the resolved data.
+   *
+   * @return array
+   *   The resolved data.
+   */
+  public function getData(): array {
+    return $this->data;
+  }
+
+  /**
+   * Sets the resolved data.
+   *
+   * @param array $data
+   *   The resolved data.
+   */
+  public function setData(array $data): void {
+    $this->data = $data;
+  }
+
+}

--- a/src/Event/OembedResolverSource.php
+++ b/src/Event/OembedResolverSource.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_oembed\Event;
+
+use Drupal\media\MediaInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Used for resolving other sources for the OembedResolver.
+ */
+class OembedResolverSource extends Event {
+
+  /**
+   * The name of the event.
+   */
+  const OEMBED_RESOLVER_SOURCE = 'oembed_resolver_source';
+
+  /**
+   * The media entity being resolved.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  protected $media;
+
+  /**
+   * The query params in the resource URL.
+   *
+   * @var array
+   */
+  protected $queryParams = [];
+
+  /**
+   * The resolved data to be altered.
+   *
+   * @var array
+   */
+  protected $data = [];
+
+  /**
+   * OembedResolverAlter constructor.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity being resolved.
+   * @param array $query_params
+   *   The query params in the resource URL.
+   */
+  public function __construct(MediaInterface $media, array $query_params) {
+    $this->media = $media;
+    $this->queryParams = $query_params;
+  }
+
+  /**
+   * Returns the media entity.
+   *
+   * @return \Drupal\media\MediaInterface
+   *   The media entity.
+   */
+  public function getMedia(): MediaInterface {
+    return $this->media;
+  }
+
+  /**
+   * Returns the resource URL query parameters.
+   *
+   * @return array
+   *   The query params.
+   */
+  public function getQueryParams(): array {
+    return $this->queryParams;
+  }
+
+  /**
+   * Returns the resolved data.
+   *
+   * @return array
+   *   The resolved data.
+   */
+  public function getData(): array {
+    return $this->data;
+  }
+
+  /**
+   * Sets the resolved data.
+   *
+   * @param array $data
+   *   The resolved data.
+   */
+  public function setData(array $data): void {
+    $this->data = $data;
+  }
+
+}

--- a/tests/Functional/OembedServiceTest.php
+++ b/tests/Functional/OembedServiceTest.php
@@ -27,6 +27,7 @@ class OembedServiceTest extends BrowserTestBase {
     'media',
     'oe_oembed',
     'user',
+    'media_test_source',
   ];
 
   /**

--- a/tests/Traits/OembedTestTrait.php
+++ b/tests/Traits/OembedTestTrait.php
@@ -28,6 +28,7 @@ trait OembedTestTrait {
     $this->createMediaType('image', ['id' => 'image']);
     $this->createMediaType('oembed:video', ['id' => 'remote_video']);
     $this->createMediaType('file', ['id' => 'file']);
+    $this->createMediaType('test', ['id' => 'test']);
 
     /** @var \Drupal\media\MediaTypeInterface[] $media_types */
     $media_types = $this->container->get('entity_type.manager')->getStorage('media_type')->loadMultiple();
@@ -84,6 +85,16 @@ trait OembedTestTrait {
       'bundle' => $media_type->id(),
       'name' => $this->randomMachineName(),
       $source_field->getName() => [$file],
+    ]);
+    $media->save();
+
+    $media_type = $media_types['test'];
+    $media_source = $media_type->getSource();
+    $source_field = $media_source->getSourceFieldDefinition($media_type);
+    $media = Media::create([
+      'bundle' => $media_type->id(),
+      'name' => $this->randomMachineName(),
+      $source_field->getName() => 'Test',
     ]);
     $media->save();
   }

--- a/tests/modules/oe_oembed_test/oe_oembed_test.info.yml
+++ b/tests/modules/oe_oembed_test/oe_oembed_test.info.yml
@@ -1,0 +1,5 @@
+name: OpenEuropa oEmbed Test
+description: Test module for the oEmbed functionality
+core: 8.x
+type: module
+package: Testing

--- a/tests/modules/oe_oembed_test/oe_oembed_test.services.yml
+++ b/tests/modules/oe_oembed_test/oe_oembed_test.services.yml
@@ -1,0 +1,9 @@
+services:
+  oe_oembed_test.alter_subscriber:
+    class: Drupal\Tests\oe_oembed\modules\oe_oembed_test\src\EventSubscriber\OembedTestAlterSubscriber
+    tags:
+      - { name: event_subscriber }
+  oe_oembed_test.source_subscriber:
+    class: Drupal\Tests\oe_oembed\modules\oe_oembed_test\src\EventSubscriber\OembedTestSourceSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/tests/modules/oe_oembed_test/src/EventSubscriber/OembedTestAlterSubscriber.php
+++ b/tests/modules/oe_oembed_test/src/EventSubscriber/OembedTestAlterSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_oembed\modules\oe_oembed_test\src\EventSubscriber;
+
+use Drupal\oe_oembed\Event\OembedResolverAlter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Test event subscriber for the OembedResolverAlter event.
+ */
+class OembedTestAlterSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      OembedResolverAlter::OEMBED_RESOLVER_ALTER => 'alterResolver',
+    ];
+  }
+
+  /**
+   * Handles the alteration.
+   *
+   * @param \Drupal\oe_oembed\Event\OembedResolverAlter $event
+   *   The event.
+   */
+  public function alterResolver(OembedResolverAlter $event): void {
+    $params = $event->getQueryParams();
+    if (isset($params['alter'])) {
+      $data = $event->getData();
+      $data['alter'] = 'altered';
+      $event->setData($data);
+    }
+  }
+
+}

--- a/tests/modules/oe_oembed_test/src/EventSubscriber/OembedTestSourceSubscriber.php
+++ b/tests/modules/oe_oembed_test/src/EventSubscriber/OembedTestSourceSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_oembed\modules\oe_oembed_test\src\EventSubscriber;
+
+use Drupal\oe_oembed\Event\OembedResolverSource;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Test event subscriber for the OembedResolverSource event.
+ */
+class OembedTestSourceSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      OembedResolverSource::OEMBED_RESOLVER_SOURCE => 'resolveSource',
+    ];
+  }
+
+  /**
+   * Resolve a given source.
+   *
+   * @param \Drupal\oe_oembed\Event\OembedResolverSource $event
+   *   The event.
+   */
+  public function resolveSource(OembedResolverSource $event): void {
+    $media = $event->getMedia();
+    $source = $media->getSource();
+    if ($source->getPluginId() !== 'test') {
+      return;
+    }
+
+    $data = [
+      'version' => '1.0',
+      'type' => 'rich',
+      'html' => '<p>This is data resolved from a test source</p>',
+    ];
+
+    $event->setData($data);
+    $event->stopPropagation();
+  }
+
+}


### PR DESCRIPTION
Extended the oEmbed resolver to allow other modules to alter the resolved data and to resolve media which use other source plugins not covered by core.