### PR TITLE
Change the CKEditor dependency to CKEditor 5. CKEditor 4 is deprecated and will be removed in Drupal 10.

### DIFF
--- a/oe_oembed.info.yml
+++ b/oe_oembed.info.yml
@@ -7,4 +7,4 @@ core_version_requirement: ^9.4 || ^10
 
 dependencies:
   - embed:embed
-  - drupal:ckeditor
+  - drupal:ckeditor5


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

Since the CKEditor module is deprecated in Drupal 9 and will be removed in Drupal 10 we need to rename the CKEditor module dependency.

### Change log

- Added: CKEditor 5 as a dependency.
- Removed: CKEditor as a dependency.