### PR TITLE
D8EMA-1350: Remove CKEditor4 dependency.

### DIFF
--- a/oe_oembed.info.yml
+++ b/oe_oembed.info.yml
@@ -7,4 +7,3 @@ core_version_requirement: ^9.4 || ^10
 
 dependencies:
   - embed:embed
-  - drupal:ckeditor


### PR DESCRIPTION
## OPENEUROPA OE_OEMBED #50

### Description

Removed CKEditor4 dependency not needed due to support added for CKEditor5.

### Change log

- Removed: CKEDitor4 dependency.